### PR TITLE
Nix: Setup Flake, DevShell, and Packages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /target
+result

--- a/README.md
+++ b/README.md
@@ -86,6 +86,37 @@ PREFIX=/usr/local ./install.sh
 You may need to log out and back in for the application icon to appear in your
 launcher.
 
+### Nix
+
+A [Nix flake](https://nix.dev/concepts/flakes) is provided. You can run
+Wallrus directly without installing:
+
+```
+nix run github:megakode/wallrus
+```
+
+To add it to a NixOS configuration:
+
+```nix
+# flake.nix
+{
+  inputs.wallrus.url = "github:megakode/wallrus";
+  # ...
+}
+
+# configuration.nix
+environment.systemPackages = [
+  inputs.wallrus.packages.${pkgs.system}.default
+];
+```
+
+A development shell with all native dependencies, `rust-analyzer`, `clippy`,
+and `rustfmt` is also available:
+
+```
+nix develop
+```
+
 ## Custom palettes
 
 Palette images are 1x4 px PNGs — one pixel per color, top to bottom (4 colors

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,27 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1771207753,
+        "narHash": "sha256-b9uG8yN50DRQ6A7JdZBfzq718ryYrlmGgqkRm9OOwCE=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "d1c15b7d5806069da59e819999d70e1cec0760bf",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,37 @@
+{
+  description = "Wallrus — Gnome (GTK4) application to generate colorful wallpapers based on gradients and different effects";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
+  };
+
+  outputs = {
+    self,
+    nixpkgs,
+  }: let
+    supportedSystems = [
+      "x86_64-linux"
+      "aarch64-linux"
+    ];
+    forAllSystems = nixpkgs.lib.genAttrs supportedSystems;
+  in {
+    packages = forAllSystems (
+      system: let
+        pkgs = nixpkgs.legacyPackages.${system};
+      in {
+        wallrus = pkgs.callPackage ./nix/package.nix {};
+        default = self.packages.${system}.wallrus;
+      }
+    );
+
+    devShells = forAllSystems (
+      system: let
+        pkgs = nixpkgs.legacyPackages.${system};
+      in {
+        default = pkgs.callPackage ./nix/devShell.nix {
+          wallrus = self.packages.${system}.wallrus;
+        };
+      }
+    );
+  };
+}

--- a/nix/devShell.nix
+++ b/nix/devShell.nix
@@ -1,0 +1,20 @@
+{
+  mkShell,
+  wallrus,
+  cargo,
+  rustc,
+  rust-analyzer,
+  clippy,
+  rustfmt,
+}:
+
+mkShell {
+  inputsFrom = [ wallrus ];
+  packages = [
+    cargo
+    rustc
+    rust-analyzer
+    clippy
+    rustfmt
+  ];
+}

--- a/nix/package.nix
+++ b/nix/package.nix
@@ -1,0 +1,83 @@
+{
+  lib,
+  rustPlatform,
+  pkg-config,
+  wrapGAppsHook4,
+  gtk4,
+  libadwaita,
+  glib,
+  cairo,
+  pango,
+  gdk-pixbuf,
+  graphene,
+  libglvnd,
+  gsettings-desktop-schemas,
+}:
+rustPlatform.buildRustPackage {
+  pname = "wallrus";
+  version = "0.1.0";
+
+  src = lib.fileset.toSource {
+    root = ./..;
+    fileset = lib.fileset.unions [
+      ./../Cargo.toml
+      ./../Cargo.lock
+      ./../src
+      ./../data
+    ];
+  };
+
+  cargoLock.lockFile = ./../Cargo.lock;
+
+  nativeBuildInputs = [
+    pkg-config
+    wrapGAppsHook4
+  ];
+
+  buildInputs = [
+    gtk4
+    libadwaita
+    glib
+    cairo
+    pango
+    gdk-pixbuf
+    graphene
+    libglvnd
+    gsettings-desktop-schemas
+  ];
+
+  postInstall = ''
+    # Desktop file
+    install -Dm644 data/com.megakode.Wallrus.desktop \
+      $out/share/applications/com.megakode.Wallrus.desktop
+
+    # Icon
+    install -Dm644 data/icons/com.megakode.Wallrus.svg \
+      $out/share/icons/hicolor/scalable/apps/com.megakode.Wallrus.svg
+
+    # AppStream metainfo
+    install -Dm644 data/com.megakode.Wallrus.metainfo.xml \
+      $out/share/metainfo/com.megakode.Wallrus.metainfo.xml
+
+    # Bundled palettes
+    mkdir -p $out/share/wallrus/palettes
+    cp -r data/palettes/* $out/share/wallrus/palettes/
+  '';
+
+  preFixup = ''
+    gappsWrapperArgs+=(
+      # Ensure libEGL.so.1 / libGLX.so.0 are available for dlopen at runtime
+      --prefix LD_LIBRARY_PATH : "${lib.makeLibraryPath [libglvnd]}"
+      # Shaders require desktop GL (GLSL 330 core); without this GTK4 may
+      # default to a GLES context on Wayland which only supports GLSL ES
+      --set GDK_DEBUG gl-prefer-gl
+    )
+  '';
+
+  meta = {
+    description = "A GNOME application for generating abstract wallpapers using shaders";
+    license = lib.licenses.gpl3Plus;
+    platforms = lib.platforms.linux;
+    mainProgram = "wallrus";
+  };
+}

--- a/src/palette.rs
+++ b/src/palette.rs
@@ -89,6 +89,16 @@ pub fn bundled_palettes_dir() -> Option<PathBuf> {
         }
     }
 
+    // Installed (prefix-relative): <prefix>/bin/wallrus -> <prefix>/share/wallrus/palettes
+    if let Ok(exe) = std::env::current_exe() {
+        if let Some(prefix) = exe.parent().and_then(|p| p.parent()) {
+            let prefix_path = prefix.join("share").join("wallrus").join("palettes");
+            if prefix_path.is_dir() {
+                return Some(prefix_path);
+            }
+        }
+    }
+
     // Installed: /usr/share/wallrus/palettes
     let system_path = PathBuf::from("/usr/share/wallrus/palettes");
     if system_path.is_dir() {


### PR DESCRIPTION
Hello! I was looking for a wallpaper generator like this literally yesterday, so it was great to stumble on this!

I use NixOS, so I put together a Nix flake to get Wallrus building and running. Figured others may want it, so I figured I'd throw a PR your way. Happy to adjust anything if you'd prefer a different approach.

## Nix
- `flake.nix`: entry point with packages and devShell outputs (x86_64-linux + aarch64-linux)
- `nix/package.nix`: Full package derivation: builds with `rustPlatform.buildRustPackage`, installs the desktop file, icon, metainfo, and bundled palettes. Uses `wrapGAppsHook4` for `GTK4/GSettings` integration, and adds `libglvnd` to `LD_LIBRARY_PATH` so the runtime `dlopen` of `libEGL.so.1/libGLX.so.0` works
- `nix/devShell.nix`: Dev shell with all native deps, plus `cargo`, `rustc`, `rust-analyzer`, `clippy`, and `rustfmt`

## Code Change

I made a small change in `palette.rs`: I added a prefix-relative palette lookup (`<prefix>/share/wallrus/palettes`). In a Nix store path, the binary lives at `<prefix>/bin/wallrus`, so the existing three-levels-up path and the hardcoded `/usr/share` path don't apply. This does **not** affect non-Nix installs.